### PR TITLE
Add 2 product card components

### DIFF
--- a/src/components/cards/product-card/ProductCard.svelte
+++ b/src/components/cards/product-card/ProductCard.svelte
@@ -1,0 +1,76 @@
+<script lang="ts" >
+  import type { CompanySlug } from "src/stores/company";
+  import type { IProduct } from "src/stores/products";
+
+    export let company_id: CompanySlug;
+    export let product: IProduct;
+    export let handleTrack: (name: IProduct["name"], id: IProduct["id"]) => void = () => {};
+  
+    let { id, name, price, description } = product;
+
+    function handleClick() {
+      handleTrack(name, id);
+    }
+  </script>
+  
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class="product-card" data-testid="product-card" on:click={() => handleClick()}>
+    <a class="product-link" data-testid="product-link" href={`/shop/${company_id}/product/${id}`}>
+        <div class="product-info">
+          <div class="info-top">
+            <h3 class="product-name" data-testid="product-name">{name}</h3>
+            <p class="product-description" data-testid="product-description">{description}</p>
+          </div>
+          <p class="product-price" data-testid="product-price">${price}</p>
+        </div>
+    </a>
+  </div>
+  
+  <style>
+    h3, p, div {
+      padding: 0;
+      margin: 0;
+    }
+
+    .product-card {
+      width: 150px;
+      min-height: 150px;
+      user-select: none;
+      word-break: break-word;
+    }
+
+    .product-link:hover {
+      text-decoration: none;
+    }
+
+    .product-info {
+      min-height: calc(150px - 30px); /* card height - padding */ 
+      padding: 15px;
+      color: #111111;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 14px;
+      justify-content: space-between;
+    }
+
+    .product-info .info-top > *, .product-info > * {
+      font-weight: 600;
+    }
+
+    .info-top {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .product-name {
+      font-size: 20px;
+    }
+
+    .product-price {
+      display: flex;
+      align-self: flex-end;
+    }
+  </style>
+  

--- a/src/components/cards/product-card/__tests__/component.test.js
+++ b/src/components/cards/product-card/__tests__/component.test.js
@@ -1,0 +1,58 @@
+import ProductCard from "../ProductCard.svelte";
+import { render, fireEvent, screen, cleanup } from "@testing-library/svelte";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const props = {
+  company_id: "test_company",
+  product: {
+    id: "123",
+    name: "Test Product",
+    description: "Test Description",
+    price: 10,
+  },
+  handleTrack: vi.fn(),
+};
+
+describe("Product Card component", () => {
+  afterEach(cleanup);
+
+  it("should render the component", () => {
+    render(ProductCard, props);
+    const card = screen.queryByTestId("product-card");
+    expect(card).toBeTruthy();
+  });
+
+  it("should render name", () => {
+    render(ProductCard, props);
+    const name = screen.queryByTestId("product-name");
+    expect(name.textContent).toContain(props.product.name);
+  });
+
+  it("should render description", () => {
+    render(ProductCard, props);
+    const description = screen.queryByTestId("product-description");
+    expect(description.textContent).toContain(props.product.description);
+  });
+
+  it("should render price", () => {
+    render(ProductCard, props);
+    const price = screen.queryByTestId("product-price");
+    expect(price.textContent).toContain(props.product.price);
+  });
+
+  it("should render link to product page and pass company_id and product_id", () => {
+    render(ProductCard, props);
+    const link = screen.queryByTestId("product-link");
+    expect(link.href).toContain(props.company_id);
+    expect(link.href).toContain(props.product.id);
+  });
+
+  it("should call handleTrack function when card is clicked", () => {
+    render(ProductCard, props);
+    const card = screen.queryByTestId("product-card");
+
+    fireEvent.click(card);
+
+    expect(props.handleTrack).toHaveBeenCalled();
+  });
+});

--- a/src/components/cards/product-card/product-card.md
+++ b/src/components/cards/product-card/product-card.md
@@ -1,0 +1,35 @@
+# Product Card Card
+
+The Product Card component is a Svelte component that displays a card with name, description and price of a product. The component supports tracking by providing a function.
+
+### Includes
+
+- Product Card component built on Svelte
+- Component test built on Testing Library + Vitest
+- Option to track the product click by providing a function
+
+## Usage
+
+```js
+<script>
+    import ProductCard from './ProductCard.svelte';
+</script>
+    <ProductCard 
+    company_id={company_id}
+    product={product}
+    // handleTrack={exampleFunction} -> optional
+    />
+
+```
+## Props
+
+- **company_id**: The company slug of the product, used for routing.
+
+- **product**: An object of the shape IProduct that contains the information of the product.
+
+- **handleTrack**: A function to be called when the card is clicked. The function should receive two parameters, the name and id of the product.
+
+## Preview
+
+![Preview](https://i.imgur.com/2Goz8An.png) 
+*border is only for visibility

--- a/src/components/cards/product-media-card/ProductMediaCard.svelte
+++ b/src/components/cards/product-media-card/ProductMediaCard.svelte
@@ -1,0 +1,148 @@
+<script lang="ts" >
+  import type { CompanySlug } from "src/stores/company";
+  import type { IProduct } from "src/stores/products";
+
+    type Variant = "primary" | "hover-shadow" | "shadow"
+
+    export let company_id: CompanySlug;
+    export let product: IProduct;
+    export let variant: Variant;
+    export let handleTrack: (name: IProduct["name"], id: IProduct["id"]) => void = () => {};
+  
+    //product
+    let { id, name, price, videos, images, videos_count, images_count } = product;
+    let variants: Variant[] = ["primary","hover-shadow","shadow"];
+    let class_name: string = (variants.includes(variant)) ? `product-media-card ${variant}` : `product-media-card ${variants[0]}` 
+    
+    // overlay
+    let overlay_class_name: string = (variant === "shadow") ? "product-overlay" : "product-overlay hidden";
+
+    // media
+    let image_src: string | undefined = images[0]?.public_id 
+    let video: HTMLVideoElement | undefined; // video tag
+    let video_sources: string[] | undefined= videos.map(video => video.public_id);
+    let video_index: number = 0; // index used to manage what video is playing
+    let video_src: string | undefined = video_sources[video_index];
+
+    function handleClick() {
+      handleTrack(name, id);
+    }
+
+    function handleHover(hover: boolean) {
+      if (variant === "hover-shadow") {
+        overlay_class_name = (hover) ? "product-overlay hover" : "product-overlay hidden";
+      }
+    }
+
+    function handleVideoEnded(index: number = 0) { // reproduces all video_sources in order
+      if (video) {
+        (index < video_sources.length - 1) 
+        ? video.src = video_sources[index + 1] 
+        : video.src = video_sources[0]
+
+        video_index = (index < video_sources.length - 1) ? index + 1 : 0;
+      }
+    }
+  </script>
+  
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+  <div class={class_name} data-testid="product-media-card" 
+    on:click={() => handleClick()}
+    on:mouseover={() => handleHover(true)}
+    on:mouseout={() => handleHover(false)}
+    >
+    <a data-testid="product-link" href={`/shop/${company_id}/product/${id}`}>
+      {#if videos_count > 0}
+        <video data-testid="product-video" bind:this={video} src={video_src} autoplay muted on:ended={() => handleVideoEnded(video_index)} />
+      {:else if images_count > 0}
+          <img data-testid="product-image" src={image_src} alt={name} />
+      {/if}
+      <div class={overlay_class_name} data-testid="product-overlay">
+        <div class="product-info">
+          <h3 class="product-name" data-testid="product-name">{name}</h3>
+          <p class="product-price" data-testid="product-price">${price}</p>
+        </div>
+      </div>
+    </a>
+  </div>
+  
+  <style>
+    h3, p, div {
+      padding: 0;
+      margin: 0;
+    }
+
+    .product-media-card {
+      width: 150px;
+      height: 150px;
+      position: relative;
+      user-select: none;
+    }
+
+    video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .product-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(0deg, rgba(54, 54, 54, 0.62) 0%, rgba(255, 255, 255, 0) 100%);
+      display: flex;
+      justify-content: flex-end;
+      align-items: flex-end;
+    }
+    
+    .product-overlay.hidden {
+      display: none;
+    }
+    
+    .product-overlay.hover {
+      display: flex;
+      animation: fade-in 0.2s ease-in-out;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    .product-media-card.hover-shadow:hover .product-overlay {
+      opacity: 1;
+    }
+
+    .product-media-card.shadow .product-overlay {
+      opacity: 1;
+    }
+
+    .product-info {
+      padding: 8px 13px;
+      color: #f3f3f4;
+      text-align: right;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 12px;
+    }
+
+    .product-name {
+      font-weight: 600;
+      font-size: 19px;
+    }
+  </style>
+  

--- a/src/components/cards/product-media-card/__tests__/component.test.js
+++ b/src/components/cards/product-media-card/__tests__/component.test.js
@@ -1,0 +1,178 @@
+import ProductMediaCard from "../ProductMediaCard.svelte";
+import { render, fireEvent, screen, cleanup } from "@testing-library/svelte";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const props = {
+  company_id: "test_company",
+  product: {
+    id: "123",
+    name: "Test Product",
+    price: 10,
+    videos: [
+      {
+        id: "test_video_1",
+        public_id: "test_video_1",
+      },
+      {
+        id: "test_video_2",
+        public_id: "test_video_2",
+      },
+    ],
+    images: [
+      {
+        id: "test_image_1",
+        public_id: "test_image_1",
+      },
+      {
+        id: "test_image_2",
+        public_id: "test_image_2",
+      },
+    ],
+    videos_count: 2,
+    images_count: 2,
+  },
+  variant: "primary",
+  handleTrack: vi.fn(),
+};
+
+const variants = ["primary", "hover-shadow", "shadow"];
+
+describe("Product Media Card component", () => {
+  afterEach(cleanup);
+
+  it("should render the component", () => {
+    render(ProductMediaCard, props);
+    const card = screen.queryByTestId("product-media-card");
+
+    expect(card).toBeTruthy();
+  });
+
+  describe("should render different variants", () => {
+    variants.forEach((variant) => {
+      it(`should render ${variant} variant class`, () => {
+        render(ProductMediaCard, { ...props, variant });
+        const card = screen.queryByTestId("product-media-card");
+
+        expect(card.className).toContain("product-media-card " + variant);
+      });
+    });
+
+    it("when variant is not in the list, should render a default variant", () => {
+      const wrongVariant = "test";
+      const defaultVariant = variants[0];
+      render(ProductMediaCard, { ...props, variant: wrongVariant });
+      const card = screen.queryByTestId("product-media-card");
+
+      expect(card.className).not.toContain(
+        "product-media-card " + wrongVariant
+      );
+      expect(card.className).toContain("product-media-card " + defaultVariant);
+    });
+
+    it("when variant is 'primary', overlay should always have class 'hidden'", async () => {
+      render(ProductMediaCard, { ...props, variant: "primary" });
+      const overlay = screen.queryByTestId("product-overlay");
+      expect(overlay.className).toContain("hidden");
+
+      const card = screen.queryByTestId("product-media-card");
+      await fireEvent.mouseOver(card);
+      expect(overlay.className).toContain("hidden");
+    });
+
+    it("when variant is 'hover-shadow', overlay should have class 'hover' when mouse is over card", async () => {
+      render(ProductMediaCard, { ...props, variant: "hover-shadow" });
+      const overlay = screen.queryByTestId("product-overlay");
+      expect(overlay.className).toContain("hidden");
+      expect(overlay.className).not.toContain("hover");
+
+      const card = screen.queryByTestId("product-media-card");
+      await fireEvent.mouseOver(card);
+
+      expect(overlay.className).not.toContain("hidden");
+      expect(overlay.className).toContain("hover");
+    });
+
+    it("when variant is 'shadow', overlay should never have class 'hidden'", async () => {
+      render(ProductMediaCard, { ...props, variant: "shadow" });
+      const overlay = screen.queryByTestId("product-overlay");
+      expect(overlay.className).not.toContain("hidden");
+
+      const card = screen.queryByTestId("product-media-card");
+      await fireEvent.mouseOver(card);
+
+      expect(overlay.className).not.toContain("hidden");
+    });
+  });
+
+  it("should render name", () => {
+    render(ProductMediaCard, props);
+    const name = screen.queryByTestId("product-name");
+
+    expect(name.textContent).toContain(props.product.name);
+  });
+
+  it("should render price", () => {
+    render(ProductMediaCard, props);
+    const price = screen.queryByTestId("product-price");
+
+    expect(price.textContent).toContain(props.product.price);
+  });
+
+  it("should render link to product page and pass company_id and product_id", () => {
+    render(ProductMediaCard, props);
+    const link = screen.queryByTestId("product-link");
+
+    expect(link.href).toContain(props.company_id);
+    expect(link.href).toContain(props.product.id);
+  });
+
+  it("should call handleTrack function when card is clicked", () => {
+    render(ProductMediaCard, props);
+    const card = screen.queryByTestId("product-media-card");
+
+    fireEvent.click(card);
+
+    expect(props.handleTrack).toHaveBeenCalled();
+  });
+
+  describe("media behaviour", () => {
+    it("when exist videos and images, should render videos", () => {
+      render(ProductMediaCard, props);
+      const video = screen.queryByTestId("product-video");
+      expect(video).toBeTruthy();
+
+      const image = screen.queryByTestId("product-image");
+      expect(image).toBeFalsy();
+    });
+
+    it("when exist images and not videos, should render images", () => {
+      render(ProductMediaCard, {
+        ...props,
+        product: { ...props.product, videos_count: 0 },
+      });
+
+      const video = screen.queryByTestId("product-video");
+      expect(video).toBeFalsy();
+
+      const image = screen.queryByTestId("product-image");
+      expect(image).toBeTruthy();
+    });
+
+    it("when not exist videos or images, shouldn't render media", () => {
+      render(ProductMediaCard, {
+        ...props,
+        product: {
+          ...props.product,
+          videos_count: 0,
+          images_count: 0,
+        },
+      });
+
+      const video = screen.queryByTestId("product-video");
+      expect(video).toBeFalsy();
+
+      const image = screen.queryByTestId("product-image");
+      expect(image).toBeFalsy();
+    });
+  });
+});

--- a/src/components/cards/product-media-card/product-media-card.md
+++ b/src/components/cards/product-media-card/product-media-card.md
@@ -1,0 +1,53 @@
+# Product Media Card Card
+
+The Product Media Card component is a Svelte component that displays a card with information and media of a product depending on the variant selected. The component allows for customization of the layout with different variants, and supports tracking by providing a function.
+
+### Includes
+
+- Product Media Card component built on Svelte
+- Component test built on Testing Library + Vitest
+- 3 different variants: "primary", "hover-shadow", "shadow"
+- Display images or videos in order and loop
+- Option to track the product click by providing a function
+
+## Usage
+
+```js
+<script>
+    import ProductMediaCard from './ProductMediaCard.svelte';
+</script>
+    <ProductMediaCard 
+    company_id={company_id}
+    product={product}
+    variant="primary"
+    // handleTrack={exampleFunction} -> optional
+    />
+
+```
+## Props
+
+- **company_id**: The company slug of the product, used for routing.
+
+- **product**: An object of the shape IProduct that contains the information and media of the product.
+
+- **variant**: The variant style of the card. Can be "primary", "hover-shadow", or "shadow". Default is "primary".
+
+- **handleTrack**: A function to be called when the card is clicked. The function should receive two parameters, the name and id of the product.
+
+## Preview
+
+### Primary
+
+![Primary](https://i.imgur.com/Gi42J0F.png) 
+"Primary" variant displays only the media of the product
+
+### Hover Shadow
+
+![Hover Shadow](https://i.imgur.com/IyleKGe.gif)
+"Hover Shadow" variant displays the media of the product and a shadow overlay with the product information when hovered
+
+### Shadow
+
+![Shadow](https://i.imgur.com/G5k4U9g.png)
+"Shadow" variant displays the media of the product and a static shadow overlay with the product information.
+


### PR DESCRIPTION
# What is the objective?

Improve the quality of content and experience on the images page. Users should get information easily and help them to decide what to eat. 

Make best product card ever.

# User story

As a user, I want to see product images and videos, so I can decide waht to try out. Enery invested in deciding and exploring the options should be reduced.

# Acceptance criteria

- Implement multiple variants except for the reaction product card
- Users can see the product title and prices instantly
- Users can click the product and it will navigate to the product detail page
- Users wil see the video playing in a series one by one
- Shadow background is required in some variants
- Pressing product card should send a track event (Needs some investigation)
- If you think animation is required, please implement it.

# Technical Notes

- Responsive design is hard, so make sure you test important viewports
- Apply shadow background

# What should be tested

Tests should be in cypress and they should open windows to check variants.

# QA Notes

None

# Engineering Pitfalls

Testing: 

**await fireEvent.mouseOver(card);**

fireEvent.mouseOver() needs async await to display the effect in the DOM.
In other fireEvent methods it is not always necessary.