### PR TITLE
Add skeleton to home title

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
     CategoryScale,
   } from "chart.js";
   import { user, type IUser } from "../stores/user";
+  import Skeleton from "../components/skeleton/Skeleton.svelte";
 
   ChartJS.register(
     Title,
@@ -65,8 +66,7 @@
   });
 
   const handleButtonTrack = (button_name: string) => {
-    analytics.track.buttonClick(button_name, {
-      page: HOME_PAGE,
+    analytics.track.buttonClick(HOME_PAGE, button_name, {
       title_value,
     });
   };
@@ -82,9 +82,17 @@
 <main>
   <div class="row">
     <div>
-      {#if title_value}
-        <h1>{$_(title_value)}</h1>
-      {/if}
+      <div class="title">
+        <Skeleton
+          loading={!title_value}
+          rows={{ default: 3 }}
+          rows_width_percent={{ default: [40, 60, 80], desktop: [60, 80, 100] }}
+          row_height={{ default: 32, desktop: 42 }}
+          gap={{ default: 15, desktop: 26 }}
+        >
+          <h1>{$_(title_value)}</h1>
+        </Skeleton>
+      </div>
       <p>
         {$_("home_description")}
       </p>
@@ -173,6 +181,14 @@
 
   .divider {
     margin-top: 80px;
+  }
+
+  .title {
+    margin: 32px 0;
+  }
+
+  .title h1 {
+    margin: 0;
   }
 
   h1 {


### PR DESCRIPTION
Necesitamos agregar skeleton al home title para evitar una mala UX. El title carga cuando termina de cargar el cliente, porque depende del Flagsmith.

_Antes de aprobar este PR es necesario aprobar el PR de review index page, allí se encuentra el componente "Skeleton.svelte"_

### Vista con skeleton
<img src="https://user-images.githubusercontent.com/70335515/231286029-757ad0af-d644-4c05-a0ae-88499c9445bd.gif" height="300">

