### PR TITLE
Connect profile page with the endpoint

### DIFF
--- a/cypress/e2e/Profiling_page.cy.js
+++ b/cypress/e2e/Profiling_page.cy.js
@@ -12,7 +12,7 @@ describe("Profiling Page", () => {
   });
 
   context("shop name validation", () => {
-    it("check error message when shop name is empty", () => {
+    it("checks error message when shop name is empty", () => {
       cy.get("[data-testid=submit-button]").click();
       console.log(translation);
 
@@ -21,7 +21,7 @@ describe("Profiling Page", () => {
       );
     });
 
-    it("check error message when shop name is too short", () => {
+    it("checks error message when shop name is too short", () => {
       const shortName = "ab";
 
       cy.get("[data-testid=shop-name-input]").clear().type(shortName).blur();
@@ -31,7 +31,7 @@ describe("Profiling Page", () => {
       );
     });
 
-    it("check error message when shop name is too long", () => {
+    it("checks error message when shop name is too long", () => {
       const longName = Array(32).join("a"); // this will create a string with 31 characters
 
       cy.get("[data-testid=shop-name-input]").clear().type(longName).blur();
@@ -41,7 +41,7 @@ describe("Profiling Page", () => {
       );
     });
 
-    it("check error message when shop name has special characters", () => {
+    it("checks error message when shop name has special characters", () => {
       const specialCharName = "shop$Name";
 
       cy.get("[data-testid=shop-name-input]")
@@ -54,7 +54,7 @@ describe("Profiling Page", () => {
       );
     });
 
-    it("check NO error message when shop name is valid", () => {
+    it("checks NO error message when shop name is valid", () => {
       const validName = "shopName";
 
       cy.get("[data-testid=shop-name-input]").clear().type(validName).blur();
@@ -64,7 +64,7 @@ describe("Profiling Page", () => {
   });
 
   context("redirection to loading page", () => {
-    it("should redirect to loading page when shop name is valid", () => {
+    it("redirects to loading page when shop name is valid", () => {
       cy.get("[data-testid=shop-name-input]").clear().type("shopName");
 
       cy.get("[data-testid=submit-button]").click();
@@ -72,7 +72,7 @@ describe("Profiling Page", () => {
       cy.url().should("include", "/loading");
     });
 
-    it("should NOT redirect to loading page when shop name is invalid", () => {
+    it("doesn't redirect to loading page when shop name is invalid", () => {
       cy.get("[data-testid=shop-name-input]").clear().type("shop$Name");
 
       cy.get("[data-testid=submit-button]").click();
@@ -97,8 +97,8 @@ describe("Profiling Page", () => {
   });
 
   context("request to server", () => {
-    let copyProductsCalled = false;
-    let checkCopyProductsStatusCalled = false;
+    let copy_pruducts_called = false;
+    let check_copy_products_status_called = false;
 
     beforeEach(() => {
       cy.intercept("PUT", "/api/v1/companies/profile").as("update_company");
@@ -106,68 +106,55 @@ describe("Profiling Page", () => {
         "POST",
         "/api/v1/companies/copy_content_from_template",
         () => {
-          copyProductsCalled = true;
+          copy_pruducts_called = true;
         }
       ).as("copy_products");
       cy.intercept(
         "GET",
         "/api/v1/companies/copy_content_from_template/*",
         () => {
-          checkCopyProductsStatusCalled = true;
+          check_copy_products_status_called = true;
         }
       ).as("check_copy_products_status");
     });
 
-    it("should only UPDATE SHOP NAME request when shop name is valid and category is 'empty'", () => {
-      cy.get("[data-testid=shop-name-input]").clear().type("shopName");
-      cy.get('input[value="empty"]').should("be.checked");
+    context("name is valid and category is 'empty'", () => {
+      it("sends only UPDATE SHOP NAME request", () => {
+        cy.get("[data-testid=shop-name-input]").clear().type("shopName");
+        cy.get('input[value="empty"]').should("be.checked");
 
-      cy.get("[data-testid=submit-button]").click();
+        cy.get("[data-testid=submit-button]").click();
 
-      cy.wait("@update_company").then(({ request }) => {
-        expect(request.body.company.name).to.eq("shopName");
-      });
+        cy.wait("@update_company").then(({ request }) => {
+          expect(request.body.company.name).to.eq("shopName");
+        });
 
-      cy.then(() => {
-        expect(copyProductsCalled).to.be.false;
-        expect(checkCopyProductsStatusCalled).to.be.false;
-      });
-    });
-
-    it("should send requests when shop name is valid and a category with products is selected", () => {
-      cy.get("[data-testid=shop-name-input]").clear().type("shopName");
-      cy.get('input[value="pizza"]').check();
-
-      cy.get("[data-testid=submit-button]").click();
-
-      cy.wait("@update_company").then(({ request }) => {
-        expect(request.body.company.name).to.eq("shopName");
-      });
-
-      cy.wait("@copy_products").then(() => {
-        expect(copyProductsCalled).to.be.true;
-      });
-
-      cy.wait("@check_copy_products_status").then(() => {
-        expect(checkCopyProductsStatusCalled).to.be.true;
+        cy.then(() => {
+          expect(copy_pruducts_called).to.be.false;
+          expect(check_copy_products_status_called).to.be.false;
+        });
       });
     });
 
-    // context("showing notifications on requests", () => {
-    //   it("should show SUCCESS notification when requests are successful", () => {
-    //     cy.get("[data-testid=shop-name-input]").clear().type("shopName");
-    //     cy.get('input[value="pizza"]').check();
+    context("name is valid and a category with products is selected", () => {
+      it("sends requests", () => {
+        cy.get("[data-testid=shop-name-input]").clear().type("shopName");
+        cy.get('input[value="pizza"]').check();
 
-    //     cy.get("[data-testid=submit-button]").click();
+        cy.get("[data-testid=submit-button]").click();
 
-    //     cy.wait("@update_company");
-    //     cy.wait("@copy_products");
-    //     cy.wait("@check_copy_products_status");
+        cy.wait("@update_company").then(({ request }) => {
+          expect(request.body.company.name).to.eq("shopName");
+        });
 
-    //     cy.get("#profiling_success_notification").contains(
-    //       translation.routes.shop.profiling.success_message
-    //     );
-    //   });
-    // });
+        cy.wait("@copy_products").then(() => {
+          expect(copy_pruducts_called).to.be.true;
+        });
+
+        cy.wait("@check_copy_products_status").then(() => {
+          expect(check_copy_products_status_called).to.be.true;
+        });
+      });
+    });
   });
 });

--- a/src/api/company.ts
+++ b/src/api/company.ts
@@ -4,9 +4,22 @@ import type { CompanySlug, ICompany } from "src/stores/company";
 interface IResponse {
   data: ICompany;
 }
+
+interface IUpdateParams extends Partial<ICompany> {}
+
 export const get_company = async (
   company_id: CompanySlug
 ): Promise<IResponse> => {
   const response = await client.get(`/api/v1/companies/${company_id}`);
+  return response.data;
+};
+
+export const updateCompany = async (
+  params: IUpdateParams
+): Promise<ICompany> => {
+  const response = await client.put("/api/v1/companies/profile", {
+    company: params,
+  });
+
   return response.data;
 };

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -1,6 +1,6 @@
 import client from "./client";
 import type { IProduct } from "src/stores/products";
-import type { CompanySlug } from "src/stores/company";
+import type { CompanySlug, ICompany } from "src/stores/company";
 
 interface IResponseProducts {
   data: { [key: string]: IProduct };
@@ -9,6 +9,14 @@ interface IResponseProducts {
 
 interface IResponseProduct {
   data: IProduct;
+}
+
+interface IResponseCopyProducts {
+  job_id: string;
+}
+
+interface IResponseCopyProductsStatus {
+  status: string;
 }
 
 export const getProducts = async (
@@ -27,6 +35,29 @@ export const getProduct = async (
   product_id: IProduct["id"]
 ): Promise<IResponseProduct> => {
   const response = await client.get(`/api/v1/product/${product_id}`);
+
+  return response.data;
+};
+
+export const copyProductsFromCompany = async (
+  template_company_id: ICompany["id"]
+): Promise<IResponseCopyProducts> => {
+  const response = await client.post(
+    `/api/v1/companies/copy_content_from_template`,
+    {
+      template_company_id,
+    }
+  );
+
+  return response.data;
+};
+
+export const checkCopyProductsStatus = async (
+  job_id: string
+): Promise<IResponseCopyProductsStatus> => {
+  const response = await client.get(
+    `/api/v1/companies/copy_content_from_template/${job_id}`
+  );
 
   return response.data;
 };

--- a/src/components/profiling-form/ProfilingForm.svelte
+++ b/src/components/profiling-form/ProfilingForm.svelte
@@ -3,7 +3,10 @@
   import Button from "../button/Button.svelte";
   import type { CompanyCategory } from "src/stores/company";
 
-  export let createShop: (shop_name: string, category: CompanyCategory) => void;
+  export let handleSubmitCallback: (
+    shop_name: string,
+    category: CompanyCategory
+  ) => void;
 
   const categories: CompanyCategory[] = ["empty", "pizza", "coffee", "stakes"];
   let category_selected: CompanyCategory = "empty";
@@ -37,7 +40,7 @@
     if (error) {
       return;
     } else {
-      createShop(shop_name, category_selected);
+      handleSubmitCallback(shop_name, category_selected);
     }
   }
 </script>
@@ -87,9 +90,9 @@
     </div>
     <div class="categories_description">
       <p style="font-weight: 600;">
-        {$_("routes.shop.profiling.categories_description_title")}
+        {$_("components.profiling_form.categories_description_title")}
       </p>
-      <p>{$_("routes.shop.profiling.categories_description")}</p>
+      <p>{$_("components.profiling_form.categories_description")}</p>
     </div>
   </div>
   <div class="profiling_submit">

--- a/src/components/profiling-form/ProfilingForm.svelte
+++ b/src/components/profiling-form/ProfilingForm.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
   import Button from "../button/Button.svelte";
+  import type { CompanyCategory } from "src/stores/company";
 
-  type Category = "pizza" | "coffee" | "stakes";
+  export let createShop: (shop_name: string, category: CompanyCategory) => void;
 
-  export let createShop: (shop_name: string) => void;
-
-  const categories: Category[] = ["pizza", "coffee", "stakes"];
-  let category_selected: Category = "pizza";
+  const categories: CompanyCategory[] = ["empty", "pizza", "coffee", "stakes"];
+  let category_selected: CompanyCategory = "empty";
   let shop_name: string = "";
 
   let error: boolean = false;
@@ -38,7 +37,7 @@
     if (error) {
       return;
     } else {
-      createShop(shop_name);
+      createShop(shop_name, category_selected);
     }
   }
 </script>
@@ -62,27 +61,36 @@
     {/if}
   </div>
   <div class="profiling_categories">
-    {#each categories as category}
-      <div
-        class={`profiling_category ${
-          category_selected === category ? "checked" : ""
-        }`}
-      >
-        <input
-          type="radio"
-          name="category"
-          id={category}
-          value={category}
-          on:click={() => {
-            category_selected = category;
-          }}
-          checked={category_selected === category}
-        />
-        <label for={category}>
-          {$_(`routes.shop.profiling.categories.${category}`)}
-        </label>
-      </div>
-    {/each}
+    <div class="categories">
+      {#each categories as category}
+        <div
+          class={`profiling_category ${
+            category_selected === category ? "checked" : ""
+          }`}
+        >
+          <input
+            type="radio"
+            name="category"
+            data-testid="category-input"
+            id={category}
+            value={category}
+            on:click={() => {
+              category_selected = category;
+            }}
+            checked={category_selected === category}
+          />
+          <label for={category}>
+            {$_(`routes.shop.profiling.categories.${category}`)}
+          </label>
+        </div>
+      {/each}
+    </div>
+    <div class="categories_description">
+      <p style="font-weight: 600;">
+        {$_("routes.shop.profiling.categories_description_title")}
+      </p>
+      <p>{$_("routes.shop.profiling.categories_description")}</p>
+    </div>
   </div>
   <div class="profiling_submit">
     <Button
@@ -137,10 +145,21 @@
 
   .profiling_categories {
     display: flex;
+    gap: 20px;
+  }
+
+  .categories {
+    display: flex;
     flex-direction: column;
     text-transform: capitalize;
     gap: 7px;
     padding-left: 10px;
+  }
+
+  .categories_description {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 
   .profiling_category {

--- a/src/lib/translation/en.json
+++ b/src/lib/translation/en.json
@@ -93,12 +93,17 @@
           "coffee": "Coffee",
           "stakes": "Stake"
         },
-        "categories_description_title": "Copy products from the template shop!",
-        "categories_description": "Choose a template shop, +10 products will be copied into your shop. Skip the process by selecting \"empty\" value.",
         "button": "Continue",
         "success_message": "We are creating your menu. Please wait a few seconds.",
         "error_message": "Error while creating your menu. Please try again later."
       }
+    }
+  },
+
+  "components": {
+    "profiling_form": {
+      "categories_description_title": "Copy products from the template shop!",
+      "categories_description": "Choose a template shop, +10 products will be copied into your shop. Skip the process by selecting \"empty\" value."
     }
   }
 }

--- a/src/lib/translation/en.json
+++ b/src/lib/translation/en.json
@@ -88,10 +88,13 @@
           "no_special": "Shop name can't contain special characters"
         },
         "categories": {
+          "empty": "Empty",
           "pizza": "Pizza",
           "coffee": "Coffee",
           "stakes": "Stake"
         },
+        "categories_description_title": "Copy products from the template shop!",
+        "categories_description": "Choose a template shop, +10 products will be copied into your shop. Skip the process by selecting \"empty\" value.",
         "button": "Continue",
         "success_message": "We are creating your menu. Please wait a few seconds.",
         "error_message": "Error while creating your menu. Please try again later."

--- a/src/lib/translation/es.json
+++ b/src/lib/translation/es.json
@@ -88,12 +88,14 @@
           "no_special": "El nombre de la tienda no puede contener caracteres especiales"
         },
         "categories": {
+          "empty": "Vacío",
           "pizza": "Pizza",
           "coffee": "Café",
           "stakes": "Parilla"
         },
+        "categories_description_title": "¡Copia productos de una plantilla!",
+        "categories_description": "Elige una plantilla de carta y +10 productos serán copiados a tu carta. Podés saltar este paso seleccionando la opción \"vacío\".",
         "button": "Continuar",
-
         "success_message": "Estamos creando tu carta. Por favor espera unos segundos.",
         "error_message": "Error al crear tu carta. Por favor, inténtalo de nuevo más tarde."
       }

--- a/src/lib/translation/es.json
+++ b/src/lib/translation/es.json
@@ -93,12 +93,17 @@
           "coffee": "Café",
           "stakes": "Parilla"
         },
-        "categories_description_title": "¡Copia productos de una plantilla!",
-        "categories_description": "Elige una plantilla de carta y +10 productos serán copiados a tu carta. Podés saltar este paso seleccionando la opción \"vacío\".",
         "button": "Continuar",
         "success_message": "Estamos creando tu carta. Por favor espera unos segundos.",
         "error_message": "Error al crear tu carta. Por favor, inténtalo de nuevo más tarde."
       }
+    }
+  },
+
+  "components": {
+    "profiling_form": {
+      "categories_description_title": "¡Copia productos de una plantilla!",
+      "categories_description": "Elige una plantilla de carta y +10 productos serán copiados a tu carta. Podés saltar este paso seleccionando la opción \"vacío\"."
     }
   }
 }

--- a/src/routes/shop/[company_id]/images/Products.svelte
+++ b/src/routes/shop/[company_id]/images/Products.svelte
@@ -20,7 +20,7 @@
     <h2>{$t("routes.shop.images.featured")}</h2>
     {#if products_with_media.length === 0}
       <div>
-        <span data-test="no-images">{$t("routes.shop.iamges.no_images")}</span>
+        <span data-test="no-images">{$t("routes.shop.images.no_images")}</span>
       </div>
     {:else}
       <p>

--- a/src/routes/shop/[company_id]/profiling/+page.svelte
+++ b/src/routes/shop/[company_id]/profiling/+page.svelte
@@ -24,7 +24,10 @@
     stakes: 214,
   };
 
-  const createShop = async (shop_name: string, category: CompanyCategory) => {
+  const handleSubmitCallback = async (
+    shop_name: string,
+    category: CompanyCategory
+  ) => {
     try {
       await updateCompany({ name: shop_name });
 
@@ -78,7 +81,7 @@
         {$_("routes.shop.profiling.description")}
       </p>
     </div>
-    <ProfilingForm {createShop} />
+    <ProfilingForm {handleSubmitCallback} />
   </section>
 </main>
 

--- a/src/routes/shop/[company_id]/profiling/+page.svelte
+++ b/src/routes/shop/[company_id]/profiling/+page.svelte
@@ -1,19 +1,54 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
   import { goto } from "$app/navigation";
-  import { company, type ICompany } from "../../../../stores/company";
+  import {
+    company,
+    type CompanyCategory,
+    type ICompany,
+  } from "../../../../stores/company";
   // import { PROFILING_PAGE } from "../../../../lib/analytics/types";
   // import analytics from "../../../../lib/analytics";
   import Logo from "../../../../components/Logo.svelte";
   import toast from "svelte-french-toast";
   import ProfilingForm from "../../../../components/profiling-form/ProfilingForm.svelte";
+  import { updateCompany } from "../../../../api/company";
+  import {
+    checkCopyProductsStatus,
+    copyProductsFromCompany,
+  } from "../../../../api/products";
 
-  const createShop = async (shop_name: string) => {
-    if (true) {
-      toast.success($_("routes.shop.profiling.success_message"));
+  const category_template_ids: Record<CompanyCategory, ICompany["id"]> = {
+    empty: null,
+    pizza: 201,
+    coffee: 212,
+    stakes: 214,
+  };
+
+  const createShop = async (shop_name: string, category: CompanyCategory) => {
+    try {
+      await updateCompany({ name: shop_name });
+
+      // if category is not empty, copy products from template
+      if (category !== "empty") {
+        const { job_id } = await copyProductsFromCompany(
+          category_template_ids[category]
+        );
+        const { status } = await checkCopyProductsStatus(job_id);
+
+        if (!["working", "completed"].includes(status)) {
+          throw new Error($_("routes.shop.profiling.error_message"));
+        }
+      }
+
+      toast.success($_("routes.shop.profiling.success_message"), {
+        id: "profiling_success_notification",
+      });
       goto(`/shop/${$company.id}/images/loading`);
-    } else {
-      toast.error($_("routes.shop.profiling.error_message"));
+    } catch (error) {
+      toast.error($_("routes.shop.profiling.error_message"), {
+        id: "profiling_error_notification",
+      });
+      console.error(error);
     }
   };
 
@@ -39,7 +74,7 @@
       <h1 data-testid="profiling-title">
         {$_("routes.shop.profiling.title")}
       </h1>
-      <p class="description">
+      <p class="header_description">
         {$_("routes.shop.profiling.description")}
       </p>
     </div>

--- a/src/stores/company.ts
+++ b/src/stores/company.ts
@@ -12,5 +12,6 @@ export interface ICompany {
 }
 
 export type CompanySlug = ICompany["slug"];
+export type CompanyCategory = "empty" | "pizza" | "coffee" | "stakes";
 
 export const company = writable<ICompany>(null);


### PR DESCRIPTION
# What is the objective?

Reduce the amount of cost necessary to start using the digital menu. Improve the onboarding process and automatically create the digital menu with great quality content.

# User story

As a customer, I want to clone data from template shop so I can start using product right a way.

# Acceptance criteria

- ~User can skip process when empty is selcted~
- ~Default value is empty~
- ~Update UI~
- ~Please submit how it looks on desktop~
- ~When continue is pressed, show loading and then redirect to the images page. Later images page should show the success modal. (Not in the scope)~

# Technical Notes

None

# What should be tested

- ~If loading page is shown and it should not stuck forever in loading.~
- ~If continue button tirggers validation on the shop name input. And error messages are shown.~
- ~It should make request to the server.~

# QA Notes

TBD

1. Visit the shop review page https://url.com/
2. Check if reviews get rendered
3. Check sort and filter buttons

# Previews
### Desktop:
![Desktop](https://github.com/qmfkdldks/motion-menu-consumer/assets/70335515/084994f4-3709-44f4-acb0-ff14145d4ffa)

### Mobile:
![Mobile](https://github.com/qmfkdldks/motion-menu-consumer/assets/70335515/6dfaaaf0-96a6-4f9c-8d14-f4d126418405)
